### PR TITLE
Changed homepage view to a grid format

### DIFF
--- a/duolingo_homepagegrid.user.js
+++ b/duolingo_homepagegrid.user.js
@@ -1,39 +1,46 @@
 // ==UserScript==
 // @name         Duo-homepage-grid
 // @namespace    http://tampermonkey.net/
-// @version      1.0
-// @description  Changes the lessons layout to a grid view
+// @version      0.1
+// @description  Changes the lessons layout to a big grid
 // @author       Blaarkies
 // @match        https://www.duolingo.com/
 // ==/UserScript==
 
 let setHomepageAsGrid = () => {
+    document.styleSheets[1].addRule('.i12-l > a', 'width: 100%; overflow: hidden;');
+    document.styleSheets[1].addRule('.i12-l > a > div > :first-child', 'transform: scale(0.6); height: 76px;');
     document.getElementsByClassName('LFfrA _3MLiB').item(0).style.maxWidth = 'unset';
+
     let lessonsContainer = Array.from(document.getElementsByTagName('div')).find(e => e.dataset.test == 'skill-tree');
     lessonsContainer.style.cssText += `
-display: grid;
-grid-template-columns: repeat(11, 125px);
-grid-template-rows: repeat(16, 125px);
-place-items: center;
-grid-gap: 8px;`;
+    display: grid;
+    grid-template-columns: repeat(17 ,80px);
+    grid-auto-rows: 90px;
+    place-items: center;
+    grid-gap: 6px;`;
 
     let lessons = Array.from(Array.from(lessonsContainer.childNodes).map(n => n.childNodes))
     .reduce((sum, c) => [...sum,...c],[])
-    .filter(n => ['A'].some(test => test == n.tagName))
-    .forEach(l => lessonsContainer.appendChild(l));
+    .filter(n => n.tagName == 'A');
 
-    Array.from(Array.from(lessonsContainer.childNodes))
-        .filter(n => ['DIV'].some(test => test == n.tagName))
-        .forEach(l => l.remove());
+    lessons.forEach(lesson => lessonsContainer.appendChild(lesson));
+
+    let oldLessonGroupWrappers = Array.from(Array.from(lessonsContainer.childNodes))
+        .filter(n => n.tagName == 'DIV');
+    oldLessonGroupWrappers.forEach(wrapper => wrapper.remove());
 };
 
+let needsToBeRefreshed = true;
 setInterval(() => {
     if (window.location.href == 'https://www.duolingo.com/') {
-        setHomepageAsGrid();
+        if (needsToBeRefreshed) {
+            setHomepageAsGrid();
+            needsToBeRefreshed = false;
+        }
+    } else {
+        needsToBeRefreshed = true;
     }
 }, 50);
 
-console.log('Duo-homepage-grid script ran. From blaarkies.com');
-
-
-
+console.log('Duo-homepage-grid script ran. Say thanks at blaarkies.com');

--- a/duolingo_homepagegrid.user.js
+++ b/duolingo_homepagegrid.user.js
@@ -1,0 +1,39 @@
+// ==UserScript==
+// @name         Duo-homepage-grid
+// @namespace    http://tampermonkey.net/
+// @version      1.0
+// @description  Changes the lessons layout to a grid view
+// @author       Blaarkies
+// @match        https://www.duolingo.com/
+// ==/UserScript==
+
+let setHomepageAsGrid = () => {
+    document.getElementsByClassName('LFfrA _3MLiB').item(0).style.maxWidth = 'unset';
+    let lessonsContainer = Array.from(document.getElementsByTagName('div')).find(e => e.dataset.test == 'skill-tree');
+    lessonsContainer.style.cssText += `
+display: grid;
+grid-template-columns: repeat(11, 125px);
+grid-template-rows: repeat(16, 125px);
+place-items: center;
+grid-gap: 8px;`;
+
+    let lessons = Array.from(Array.from(lessonsContainer.childNodes).map(n => n.childNodes))
+    .reduce((sum, c) => [...sum,...c],[])
+    .filter(n => ['A'].some(test => test == n.tagName))
+    .forEach(l => lessonsContainer.appendChild(l));
+
+    Array.from(Array.from(lessonsContainer.childNodes))
+        .filter(n => ['DIV'].some(test => test == n.tagName))
+        .forEach(l => l.remove());
+};
+
+setInterval(() => {
+    if (window.location.href == 'https://www.duolingo.com/') {
+        setHomepageAsGrid();
+    }
+}, 50);
+
+console.log('Duo-homepage-grid script ran. From blaarkies.com');
+
+
+

--- a/duolingo_homepagegrid.user.js
+++ b/duolingo_homepagegrid.user.js
@@ -1,16 +1,16 @@
 // ==UserScript==
 // @name         Duo-homepage-grid
 // @namespace    http://tampermonkey.net/
-// @version      0.1
-// @description  Changes the lessons layout to a big grid
+// @version      1.0
+// @description  Changes the lessons layout to a grid view
 // @author       Blaarkies
 // @match        https://www.duolingo.com/
 // ==/UserScript==
 
 let setHomepageAsGrid = () => {
-    document.styleSheets[1].addRule('.i12-l > a', 'width: 100%; overflow: hidden;');
+    document.styleSheets[1].addRule('.i12-l > a', 'width: 100%;');
     document.styleSheets[1].addRule('.i12-l > a > div > :first-child', 'transform: scale(0.6); height: 76px;');
-    document.styleSheets[1].addRule('.i12-l > a > div > :nth-child(3)', 'position: fixed;');
+    document.styleSheets[1].addRule('.i12-l > a[title=Practice]', 'width: 70px;');
     document.getElementsByClassName('LFfrA _3MLiB').item(0).style.maxWidth = 'unset';
 
     let lessonsContainer = Array.from(document.getElementsByTagName('div')).find(e => e.dataset.test == 'skill-tree');

--- a/duolingo_homepagegrid.user.js
+++ b/duolingo_homepagegrid.user.js
@@ -10,6 +10,7 @@
 let setHomepageAsGrid = () => {
     document.styleSheets[1].addRule('.i12-l > a', 'width: 100%; overflow: hidden;');
     document.styleSheets[1].addRule('.i12-l > a > div > :first-child', 'transform: scale(0.6); height: 76px;');
+    document.styleSheets[1].addRule('.i12-l > a > div > :nth-child(3)', 'position: fixed;');
     document.getElementsByClassName('LFfrA _3MLiB').item(0).style.maxWidth = 'unset';
 
     let lessonsContainer = Array.from(document.getElementsByTagName('div')).find(e => e.dataset.test == 'skill-tree');
@@ -34,7 +35,7 @@ let setHomepageAsGrid = () => {
 let needsToBeRefreshed = true;
 setInterval(() => {
     if (window.location.href == 'https://www.duolingo.com/') {
-        if (needsToBeRefreshed) {
+        if (needsToBeRefreshed && document.styleSheets[1]) {
             setHomepageAsGrid();
             needsToBeRefreshed = false;
         }


### PR DESCRIPTION
The default linear tree is quite long to scroll down in Spanish. This script pulls out all anchor tags out of their parent divs and places them in a css grid, using the width of a normal widescreen monitor to display more lessons at once

![duo](https://user-images.githubusercontent.com/21290218/60755126-6446c000-9feb-11e9-82a2-806b95d95f71.jpg)
